### PR TITLE
Fix apple mail replies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,6 @@
+[*]
+insert_final_newline = false
+
 [*.py]
 indent_style = space
 indent_size = 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### UNRELEASED
+
+ - Fixed bug when parsing replies from Apple Mail, when a trailing `>` would be included.
+
 ### v1.0.0 2015-08-22
 
 First version of claw released, forked off from talon v1.0.2.

--- a/claw/quotations.py
+++ b/claw/quotations.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 RE_FWD = re.compile("^[-]+[ ]*Forwarded message[ ]*[-]+$", re.I | re.M)
 
 RE_ON_DATE_SMB_WROTE = re.compile(
-    u'(-*[ ]?({0})[ ].*({1})(.*\n){{0,2}}.*({2}):?-*)'.format(
+    u'(-*[>]?[ ]?({0})[ ].*({1})(.*\n){{0,2}}.*({2}):?-*)'.format(
         # Beginning of the line
         u'|'.join((
             # English
@@ -56,7 +56,7 @@ RE_ON_DATE_SMB_WROTE = re.compile(
     ))
 # Special case for languages where text is translated like this: 'on {date} wrote {somebody}:'
 RE_ON_DATE_WROTE_SMB = re.compile(
-    u'(-*[ ]?({0})[ ].*(.*\n){{0,2}}.*({1})[ ].*:)'.format(
+    u'(-*[>]?[ ]?({0})[ ].*(.*\n){{0,2}}.*({1})[ ].*:)'.format(
         # Beginning of the line
         	'Op',
         # Ending of the line

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -1,4 +1,12 @@
-STANDARD_REPLIES = "tests/fixtures/standard_replies"
+# -*- coding: utf-8 -*-
+
+import os
+
+STANDARD_REPLIES_DIR = os.path.join(os.path.dirname(__file__), "standard_replies")
+STANDARD_REPLIES_FILENAMES = [
+    os.path.join(STANDARD_REPLIES_DIR, f) for f in os.listdir(STANDARD_REPLIES_DIR)
+    if f.endswith('.eml')
+]
 
 with open("tests/fixtures/reply-quotations-share-block.eml") as f:
     REPLY_QUOTATIONS_SHARE_BLOCK = f.read()

--- a/tests/fixtures/standard_replies/apple_mail_2.eml
+++ b/tests/fixtures/standard_replies/apple_mail_2.eml
@@ -1,0 +1,19 @@
+Content-Type: text/plain;
+	charset=us-ascii
+Mime-Version: 1.0 (Mac OS X Mail 8.2 \(2104\))
+Subject: Re: Hello there
+X-Universally-Unique-Identifier: 85B1075D-5841-46A9-8565-FCB287A93AC4
+From: Adam Renberg <adam@tictail.com>
+In-Reply-To: <CABzQGhkMXDxUt_tSVQcg=43aniUhtsVfCZVzu-PG0kwS_uzqMw@mail.gmail.com>
+Date: Sat, 22 Aug 2015 19:22:20 +0200
+Content-Transfer-Encoding: 7bit
+X-Smtp-Server: smtp.gmail.com:adam@tictail.com
+Message-Id: <68001B29-8EA4-444C-A894-0537D2CA5208@tictail.com>
+References: <CABzQGhkMXDxUt_tSVQcg=43aniUhtsVfCZVzu-PG0kwS_uzqMw@mail.gmail.com>
+To: Adam Renberg <tgwizard@gmail.com>
+
+I think it looks great!
+> On 22 Aug 2015, at 19:21, Adam Renberg <tgwizard@gmail.com> wrote:
+> 
+> What do you think of this?
+

--- a/tests/fixtures/standard_replies/apple_mail_2_reply_text
+++ b/tests/fixtures/standard_replies/apple_mail_2_reply_text
@@ -1,0 +1,1 @@
+I think it looks great!

--- a/tests/fixtures/standard_replies/iphone_reply_text
+++ b/tests/fixtures/standard_replies/iphone_reply_text
@@ -1,0 +1,3 @@
+hello
+
+Sent from my iPhone


### PR DESCRIPTION
As seen in `apple_mail_2.eml`, the reply body can include an unexpected `>` on the same line as the "On date somebody wrote" line:

```

I think it looks great!
> On 22 Aug 2015, at 19:21, Adam Renberg <tgwizard@gmail.com> wrote:
> 
> What do you think of this?
```

That `>` would be included in the parsed text, but shouldn't be. This PR fixes that. This PR also cleans up the tests that check the "standard replies" fixture.
