### PR TITLE
Cache dependencies on CircleCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install test release clean-dist
+.PHONY: install test release post-dep-install clean-dist
 
 COVERAGE_SOURCES = claw
 
@@ -13,6 +13,9 @@ test:
 release: clean-dist
 	python setup.py sdist
 	twine upload dist/*
+
+post-dep-install:
+	@echo "Dependencies installed successfully"
 
 clean-dist:
 	rm -rf dist

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,8 @@
+dependencies:
+  override:
+    - tox post-dep-install
+  cache_directories:
+    - ".tox"
+test:
+  override:
+    - tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist = py27
 
 [testenv]
-whitelist_externals = make
+whitelist_externals =
+    make
 commands =
     pip install -e .[tests]
-    make test
+    make {posargs:test}


### PR DESCRIPTION
Hack around how tox and CircleCI interact by:
1. First install the dependencies (for all environments) in the dependency installation phaese
2. Then cache them (the `.tox` directory).
3. Then run the tests. This will try to install the dependencies again, but won't need to.

Nest test run on CircleCI will have the dependencies already installed.
