### PR TITLE
Install tox for CircleCI test runs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,5 +1,6 @@
 dependencies:
   override:
+    - pip install -U tox
     - tox post-dep-install
   cache_directories:
     - ".tox"


### PR DESCRIPTION
Fixes the CircleCI issues in https://github.com/tictail/claw/pull/6.
